### PR TITLE
Rename private profile type to Profile

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -20,7 +20,8 @@ const (
 	traceMode
 )
 
-type profile struct {
+// Profile represents an active profiling session.
+type Profile struct {
 	// quiet suppresses informational messages during profiling.
 	quiet bool
 
@@ -50,14 +51,14 @@ type profile struct {
 // Programs with more sophisticated signal handling should set
 // this to true and ensure the Stop() function returned from Start()
 // is called during shutdown.
-func NoShutdownHook(p *profile) { p.noShutdownHook = true }
+func NoShutdownHook(p *Profile) { p.noShutdownHook = true }
 
 // Quiet suppresses informational messages during profiling.
-func Quiet(p *profile) { p.quiet = true }
+func Quiet(p *Profile) { p.quiet = true }
 
 // CPUProfile enables cpu profiling.
 // It disables any previous profiling settings.
-func CPUProfile(p *profile) { p.mode = cpuMode }
+func CPUProfile(p *Profile) { p.mode = cpuMode }
 
 // DefaultMemProfileRate is the default memory profiling rate.
 // See also http://golang.org/pkg/runtime/#pkg-variables
@@ -65,15 +66,15 @@ const DefaultMemProfileRate = 4096
 
 // MemProfile enables memory profiling.
 // It disables any previous profiling settings.
-func MemProfile(p *profile) {
+func MemProfile(p *Profile) {
 	p.memProfileRate = DefaultMemProfileRate
 	p.mode = memMode
 }
 
 // MemProfileRate enables memory profiling at the preferred rate.
 // It disables any previous profiling settings.
-func MemProfileRate(rate int) func(*profile) {
-	return func(p *profile) {
+func MemProfileRate(rate int) func(*Profile) {
+	return func(p *Profile) {
 		p.memProfileRate = rate
 		p.mode = memMode
 	}
@@ -81,19 +82,19 @@ func MemProfileRate(rate int) func(*profile) {
 
 // BlockProfile enables block (contention) profiling.
 // It disables any previous profiling settings.
-func BlockProfile(p *profile) { p.mode = blockMode }
+func BlockProfile(p *Profile) { p.mode = blockMode }
 
 // ProfilePath controls the base path where various profiling
 // files are written. If blank, the base path will be generated
 // by ioutil.TempDir.
-func ProfilePath(path string) func(*profile) {
-	return func(p *profile) {
+func ProfilePath(path string) func(*Profile) {
+	return func(p *Profile) {
 		p.path = path
 	}
 }
 
 // Stop stops the profile and flushes any unwritten data.
-func (p *profile) Stop() {
+func (p *Profile) Stop() {
 	if !atomic.CompareAndSwapUint32(&p.stopped, 0, 1) {
 		// someone has already called close
 		return
@@ -108,14 +109,14 @@ var started uint32
 // Start starts a new profiling session.
 // The caller should call the Stop method on the value returned
 // to cleanly stop profiling.
-func Start(options ...func(*profile)) interface {
+func Start(options ...func(*Profile)) interface {
 	Stop()
 } {
 	if !atomic.CompareAndSwapUint32(&started, 0, 1) {
 		log.Fatal("profile: Start() already called")
 	}
 
-	var prof profile
+	var prof Profile
 	for _, option := range options {
 		option(&prof)
 	}

--- a/trace.go
+++ b/trace.go
@@ -5,7 +5,7 @@ package profile
 import "runtime/trace"
 
 // Trace profile controls if execution tracing will be enabled. It disables any previous profiling settings.
-func TraceProfile(p *profile) { p.mode = traceMode }
+func TraceProfile(p *Profile) { p.mode = traceMode }
 
 var startTrace = trace.Start
 var stopTrace = trace.Stop


### PR DESCRIPTION
Fixes #25 

Rename `profile.profile` to `profile.Profile`.