### PR TITLE
Moved TraceProfile to profile.go

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -84,6 +84,9 @@ func MemProfileRate(rate int) func(*Profile) {
 // It disables any previous profiling settings.
 func BlockProfile(p *Profile) { p.mode = blockMode }
 
+// Trace profile controls if execution tracing will be enabled. It disables any previous profiling settings.
+func TraceProfile(p *Profile) { p.mode = traceMode }
+
 // ProfilePath controls the base path where various profiling
 // files are written. If blank, the base path will be generated
 // by ioutil.TempDir.

--- a/trace.go
+++ b/trace.go
@@ -4,8 +4,5 @@ package profile
 
 import "runtime/trace"
 
-// Trace profile controls if execution tracing will be enabled. It disables any previous profiling settings.
-func TraceProfile(p *Profile) { p.mode = traceMode }
-
 var startTrace = trace.Start
 var stopTrace = trace.Stop

--- a/trace_test.go
+++ b/trace_test.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package profile_test
 
 import "github.com/pkg/profile"


### PR DESCRIPTION
No reason to prevent TraceProfile from being compiled on Go 1.6 and earlier since we have the mock functions in trace16.go