### PR TITLE
profile: don't assume README.md is available

### DIFF
--- a/profile_test.go
+++ b/profile_test.go
@@ -14,13 +14,20 @@ import (
 
 type checkFn func(t *testing.T, stdout, stderr []byte, err error)
 
-var profileTests = []struct {
-	name   string
-	code   string
-	checks []checkFn
-}{{
-	name: "default profile (cpu)",
-	code: `
+func TestProfile(t *testing.T) {
+	f, err := ioutil.TempFile("", "profile_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	var profileTests = []struct {
+		name   string
+		code   string
+		checks []checkFn
+	}{{
+		name: "default profile (cpu)",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -29,14 +36,14 @@ func main() {
 	defer profile.Start().Stop()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: cpu profiling enabled"),
-		NoErr,
-	},
-}, {
-	name: "memory profile",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: cpu profiling enabled"),
+			NoErr,
+		},
+	}, {
+		name: "memory profile",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -45,14 +52,14 @@ func main() {
 	defer profile.Start(profile.MemProfile).Stop()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: memory profiling enabled"),
-		NoErr,
-	},
-}, {
-	name: "memory profile (rate 2048)",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: memory profiling enabled"),
+			NoErr,
+		},
+	}, {
+		name: "memory profile (rate 2048)",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -61,14 +68,14 @@ func main() {
 	defer profile.Start(profile.MemProfileRate(2048)).Stop()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: memory profiling enabled (rate 2048)"),
-		NoErr,
-	},
-}, {
-	name: "double start",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: memory profiling enabled (rate 2048)"),
+			NoErr,
+		},
+	}, {
+		name: "double start",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -78,14 +85,14 @@ func main() {
 	profile.Start()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("cpu profiling enabled", "profile: Start() already called"),
-		Err,
-	},
-}, {
-	name: "block profile",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("cpu profiling enabled", "profile: Start() already called"),
+			Err,
+		},
+	}, {
+		name: "block profile",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -94,14 +101,14 @@ func main() {
 	defer profile.Start(profile.BlockProfile).Stop()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: block profiling enabled"),
-		NoErr,
-	},
-}, {
-	name: "mutex profile",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: block profiling enabled"),
+			NoErr,
+		},
+	}, {
+		name: "mutex profile",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -110,14 +117,14 @@ func main() {
 	defer profile.Start(profile.MutexProfile).Stop()
 }
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: mutex profiling enabled"),
-		NoErr,
-	},
-}, {
-	name: "profile path",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: mutex profiling enabled"),
+			NoErr,
+		},
+	}, {
+		name: "profile path",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -126,30 +133,30 @@ func main() {
 	defer profile.Start(profile.ProfilePath(".")).Stop()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: cpu profiling enabled, cpu.pprof"),
-		NoErr,
-	},
-}, {
-	name: "profile path error",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: cpu profiling enabled, cpu.pprof"),
+			NoErr,
+		},
+	}, {
+		name: "profile path error",
+		code: `
 package main
 
 import "github.com/pkg/profile"
 
 func main() {
-		defer profile.Start(profile.ProfilePath("README.md")).Stop()
+		defer profile.Start(profile.ProfilePath("` + f.Name() + `")).Stop()
 }	
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("could not create initial output"),
-		Err,
-	},
-}, {
-	name: "multiple profile sessions",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("could not create initial output"),
+			Err,
+		},
+	}, {
+		name: "multiple profile sessions",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -162,23 +169,23 @@ func main() {
 	profile.Start(profile.MutexProfile).Stop()
 }
 `,
-	checks: []checkFn{
-		NoStdout,
-		Stderr("profile: cpu profiling enabled",
-			"profile: cpu profiling disabled",
-			"profile: memory profiling enabled",
-			"profile: memory profiling disabled",
-			"profile: block profiling enabled",
-			"profile: block profiling disabled",
-			"profile: cpu profiling enabled",
-			"profile: cpu profiling disabled",
-			"profile: mutex profiling enabled",
-			"profile: mutex profiling disabled"),
-		NoErr,
-	},
-}, {
-	name: "profile quiet",
-	code: `
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: cpu profiling enabled",
+				"profile: cpu profiling disabled",
+				"profile: memory profiling enabled",
+				"profile: memory profiling disabled",
+				"profile: block profiling enabled",
+				"profile: block profiling disabled",
+				"profile: cpu profiling enabled",
+				"profile: cpu profiling disabled",
+				"profile: mutex profiling enabled",
+				"profile: mutex profiling disabled"),
+			NoErr,
+		},
+	}, {
+		name: "profile quiet",
+		code: `
 package main
 
 import "github.com/pkg/profile"
@@ -187,10 +194,8 @@ func main() {
         defer profile.Start(profile.Quiet).Stop()
 }       
 `,
-	checks: []checkFn{NoStdout, NoStderr, NoErr},
-}}
-
-func TestProfile(t *testing.T) {
+		checks: []checkFn{NoStdout, NoStderr, NoErr},
+	}}
 	for _, tt := range profileTests {
 		t.Log(tt.name)
 		stdout, stderr, err := runTest(t, tt.code)


### PR DESCRIPTION
Fixes #39

Don't assume README.md is in the current directly. Instead create a
temporary file to defeat the profile path test.