### PR TITLE
Move the CI to Github Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.13', '1.14', '1' ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Test
+      run: go test -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go_import_path: github.com/pkg/profile
-go:
-  - 1.13.x
-  - 1.14.x
-  - tip
-
-script:
-  - go test -race github.com/pkg/profile

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ profile
 
 Simple profiling support package for Go
 
-[![Build Status](https://travis-ci.org/pkg/profile.svg?branch=master)](https://travis-ci.org/pkg/profile) [![GoDoc](http://godoc.org/github.com/pkg/profile?status.svg)](http://godoc.org/github.com/pkg/profile)
+![Build Status](https://github.com/kmzfs/pkg/profile/workflows/go.yml/badge.svg?branch=master)
+[![GoDoc](http://godoc.org/github.com/pkg/profile?status.svg)](http://godoc.org/github.com/pkg/profile)
 
 
 installation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ profile
 
 Simple profiling support package for Go
 
-![Build Status](https://github.com/kmzfs/pkg/profile/workflows/go.yml/badge.svg?branch=master)
+![Build Status](https://github.com/pkg/profile/actions/workflows/go.yml/badge.svg?branch=master)
 [![GoDoc](http://godoc.org/github.com/pkg/profile?status.svg)](http://godoc.org/github.com/pkg/profile)
 
 


### PR DESCRIPTION
Travis-ci.org is `ceased`. I just did the migration to GH actions for two of my repos so when I saw this I thought if you also need to move this can help and took me just few minutes.

Ignore if you have other plans.
