### PR TITLE
Add clock (fgprof) profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pkg/profile
 
 go 1.13
+
+require github.com/felixge/fgprof v0.9.3

--- a/profile.go
+++ b/profile.go
@@ -12,6 +12,8 @@ import (
 	"runtime/pprof"
 	"runtime/trace"
 	"sync/atomic"
+
+	"github.com/felixge/fgprof"
 )
 
 const (
@@ -22,6 +24,7 @@ const (
 	traceMode
 	threadCreateMode
 	goroutineMode
+	clockMode
 )
 
 // Profile represents an active profiling session.
@@ -121,6 +124,10 @@ func ThreadcreationProfile(p *Profile) { p.mode = threadCreateMode }
 // GoroutineProfile enables goroutine profiling.
 // It disables any previous profiling settings.
 func GoroutineProfile(p *Profile) { p.mode = goroutineMode }
+
+// ClockProfile enables wall clock (fgprof) profiling.
+// It disables any previous profiling settings.
+func ClockProfile(p *Profile) { p.mode = clockMode }
 
 // ProfilePath controls the base path where various profiling
 // files are written. If blank, the base path will be generated
@@ -286,6 +293,20 @@ func Start(options ...func(*Profile)) interface {
 			}
 			f.Close()
 			logf("profile: goroutine profiling disabled, %s", fn)
+		}
+
+	case clockMode:
+		fn := filepath.Join(path, "clock.pprof")
+		f, err := os.Create(fn)
+		if err != nil {
+			log.Fatalf("profile: could not create clock profile %q: %v", fn, err)
+		}
+		logf("profile: clock profiling enabled, %s", fn)
+		stop := fgprof.Start(f, fgprof.FormatPprof)
+		prof.closer = func() {
+			stop()
+			f.Close()
+			logf("profile: clock profiling disabled, %s", fn)
 		}
 	}
 

--- a/profile_test.go
+++ b/profile_test.go
@@ -123,6 +123,22 @@ func main() {
 			NoErr,
 		},
 	}, {
+		name: "clock profile",
+		code: `
+package main
+
+import "github.com/pkg/profile"
+
+func main() {
+	defer profile.Start(profile.ClockProfile).Stop()
+}
+`,
+		checks: []checkFn{
+			NoStdout,
+			Stderr("profile: clock profiling enabled"),
+			NoErr,
+		},
+	}, {
 		name: "profile path",
 		code: `
 package main


### PR DESCRIPTION
This adds a profile type from https://pkg.go.dev/github.com/felixge/fgprof, which is useful as a starting place to chase performance rather than cpu/mem etc.